### PR TITLE
Display bike paths

### DIFF
--- a/data/style.json
+++ b/data/style.json
@@ -104,13 +104,11 @@
     },
     {
       "id": "radwege",
-      "type": "fill",
+      "type": "line",
       "source": "radwegeogd",
       "minzoom": 0,
       "paint": {
-        "fill-color": "rgba(192, 192, 192, 1)",
-        "fill-outline-color": "rgba(4, 4, 4, 1)",
-        "fill-opacity": 0.9
+        "line-color": "green"
       }
 
     },


### PR DESCRIPTION
Liniendaten benötigen "type": "line" und andere Darstellungsproperties. Siehe
https://www.mapbox.com/mapbox-gl-js/style-spec/#layers-line für Dokumentation.